### PR TITLE
Fixed attack input mistake

### DIFF
--- a/build/Data/menu.txt
+++ b/build/Data/menu.txt
@@ -1,0 +1,3 @@
+disablekey attack2
+disablekey attack3
+disablekey attack4


### PR DESCRIPTION
Acceptance criteria: 
Make certain attack 2, 3 and 4 do not show up in Zebler, or are not configurable keys when setting controls up.